### PR TITLE
Updates the Azure Terraform to apply in a reliable manner

### DIFF
--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -1,11 +1,3 @@
-output "pip-initial_peer" {
-  value = "${azurerm_public_ip.pip.0.ip_address}",
-}
-
-output "pip-mongodb" {
-  value = "${azurerm_public_ip.pip.1.ip_address}",
-}
-
-output "pip-np_app" {
-  value = "${azurerm_public_ip.pip.2.ip_address}",
+output "instance_ips" {
+  value = ["${azurerm_public_ip.pip.*.ip_address}"]
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -1,5 +1,5 @@
 variable "azure_region" {
-  default = "westus2"
+  default = "eastus"
 }
 
 variable "azure_public_key_path" {
@@ -31,7 +31,7 @@ variable "application" {
 }
 
 variable "habitat_origin" {
-  default = "core"
+  default = "scottford"
 }
 
 variable "bldr_url" {

--- a/terraform/templates/hab-sup.service
+++ b/terraform/templates/hab-sup.service
@@ -2,7 +2,7 @@
 Description=Habitat Supervisor
 
 [Service]
-ExecStartPre=/bin/bash -c "/bin/systemctl 
+ExecStartPre=/bin/bash -c /bin/systemctl
 ExecStart=/bin/hab run ${flags}
 
 [Install]


### PR DESCRIPTION
* Exchanges remote-exec hab provisioning for the habitat provisioner
  which fixes a race condition where the service file is unavailable
* Updates outputs to function properly
* Updates variables to have sane defaults
* Removes unnecessary double quote from hab-sup.service template