### PR TITLE
Add studiorc

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -1,0 +1,60 @@
+WHITE="$(printf '\033[1;37m')"
+BLUE="$(printf '\033[1;46m\033[1;37m')"
+NO_COLOR="$(printf '\033[0m')"
+
+start_demo() {
+  start_mongodb
+  start_parks
+}
+
+start_mongodb() {
+  runcmd "hab svc load $HAB_ORIGIN/np-mongodb"
+}
+
+start_parks() {
+  runcmd "hab svc load $HAB_ORIGIN/national-parks --bind database:np-mongodb.default --channel stable --strategy at-once"
+}
+
+stop_mongodb() {
+  runcmd "hab svc stop $HAB_ORIGIN/np-mongodb"
+}
+
+stop_parks() {
+  runcmd "hab svc stop $HAB_ORIGIN/national-parks"
+}
+
+stop_demo() {
+  stop_parks
+  stop_mongodb
+}
+
+runcmd() {
+  echo -e "${WHITE}$@${NO_COLOR}"
+
+  $@
+}
+
+help() {
+  cat <<HELP
+$BLUE
+Welcome to the National Parks Demo Studio
+
+The following commands are available in addition to the regular studio commands:
+
+1. Running National Parks
+  * start_mongodb - Starts mongodb
+  * start_parks - Starts national-parks and binds to mongodb. 
+  * * Can be run before start_mongodb to show application waiting until bind is available
+  * * Run 'sup-log' after this command to tail the Habitat Supervisor logs
+  * start_demo - Starts mongodb and national-parks
+  * stop_mongodb - Stops mongodb
+  * stop_parks - Stops national-parks
+  * stop_demo - Stops mongodb and national-parks
+2. Help
+  * help - This message$NO_COLOR
+
+
+HELP
+}
+
+help

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 ## Running in docker studio
 
 ```
+# Windows
 $env:HAB_DOCKER_OPTS="-p 8080:8080"
+# Linux
+export HAB_DOCKER_OPTS="-p 8080:8080"
+
+
 hab studio enter
-hab start mwrock/np-mongodb
-hab start mwrock/national-parks --bind database:np-mongodb.default
+start_parks
+
 ```
 
 Open your browser to `https://localhost:8080/national-parks` to see the app.


### PR DESCRIPTION
This adds some helper functions via .studiorc to manage the national parks app.  It also provides some help documentation when you enter the studio.  If the colors are 👎 I'm happy to change to whatever is easiest for people to read. 

![national-parks docker 2018-03-12 09-49-05](https://user-images.githubusercontent.com/36851/37308047-03354dde-25fa-11e8-8d94-f84cd97a49ce.png)
